### PR TITLE
added parenthesis matching on REPL prompt

### DIFF
--- a/ConsoleEdit.cpp
+++ b/ConsoleEdit.cpp
@@ -708,6 +708,15 @@ void ConsoleEdit::onCursorPositionChanged() {
         setReadOnly(false);
         viewport()->setCursor(Qt::IBeamCursor);
     }
+
+    if (pmatched.size()) {
+        pmatched.format_both(c);
+        pmatched = ParenMatching::range();
+    }
+
+    ParenMatching pm(c);
+    if (pm)
+        (pmatched = pm.positions).format_both(c, pmatched.bold());
 }
 
 /** check if line content is appropriate, then highlight or open editor on it */

--- a/ConsoleEdit.h
+++ b/ConsoleEdit.h
@@ -50,6 +50,7 @@
 
 #include "SwiPrologEngine.h"
 #include "Completion.h"
+#include "ParenMatching.h"
 
 #include <QElapsedTimer>
 
@@ -243,6 +244,11 @@ protected:
 
     /** relax selection check requirement */
     QElapsedTimer sel_check_timing;
+
+protected:
+
+    /** keep last matched pair */
+    ParenMatching::range pmatched;
 
 public slots:
 


### PR DESCRIPTION
The added functionality (see the matching parenthesis on command line) is what really should have been from the start - I remember the previous fork and poll request was split in two - may the last one was lost.