### PR TITLE
Fix autocomplete

### DIFF
--- a/Completion.cpp
+++ b/Completion.cpp
@@ -74,9 +74,12 @@ QString Completion::initialize(int promptPosition, QTextCursor c, QStringList &s
         PlString After(after.toStdWString().data());
 
         PlTerm Completions, Delete, word;
-        if (PlCall("prolog", "complete_input", PlTermv(Before, After, Delete, Completions)))
-            for (PlTail l(Completions); l.next(word); )
+        if (PlCall("prolog", "complete_input", PlTermv(Before, After, Delete, Completions))) {
+            PlTail l(Completions); // cautiously make an explicit call to close
+            while (l.next(word))
                 strings.append(t2w(word));
+            l.close();
+        }
 
         c.setPosition(p);
         rets = t2w(Delete);

--- a/ConsoleEdit.cpp
+++ b/ConsoleEdit.cpp
@@ -440,7 +440,7 @@ void ConsoleEdit::compinit2(QTextCursor c) {
     QStringList lpreds;
     foreach (auto a, atoms) {
         auto p = Completion::pred_docs.constFind(a);
-        if (p != Completion::pred_docs.end())
+        if (p != Completion::pred_docs.constEnd()) // was pred_docs.end(), seems a Qt bug it's allowed
             foreach (auto d, p.value()) {
                 QStringList la;
                 for (int n = 0; n < d.first; ++n)

--- a/ConsoleEdit.cpp
+++ b/ConsoleEdit.cpp
@@ -708,6 +708,15 @@ void ConsoleEdit::onCursorPositionChanged() {
         setReadOnly(false);
         viewport()->setCursor(Qt::IBeamCursor);
     }
+
+    if (pmatched.size()) {
+        pmatched.format_both(c);
+        pmatched = ParenMatching::range();
+    }
+
+    ParenMatching pm(c);
+    if (pm)
+        (pmatched = pm.positions).format_both(c, pmatched.bold());
 }
 
 /** check if line content is appropriate, then highlight or open editor on it */

--- a/ConsoleEdit.h
+++ b/ConsoleEdit.h
@@ -50,6 +50,7 @@
 
 #include "SwiPrologEngine.h"
 #include "Completion.h"
+#include "ParenMatching.h"
 
 #include <QElapsedTimer>
 
@@ -243,6 +244,11 @@ protected:
 
     /** relax selection check requirement */
     QElapsedTimer sel_check_timing;
+
+protected:
+
+    /** keep last matched pair */
+    ParenMatching::range pmatched;
 
 public slots:
 


### PR DESCRIPTION
Seems there is a bug in Qt, allowing to compare a container.constFind() initialized iterator against a container.end(), and then crash scanning the data.

I'm resuming development of this package, adding CUA editing :) Qt style, hope this preliminary PR will get merged, maybe I will follow up with something more.

Thanks, Carlo
