### PR TITLE
FIX: add ESC sequence for 8 bit and true color

### DIFF
--- a/ansi_esc_seq.cpp
+++ b/ansi_esc_seq.cpp
@@ -117,7 +117,7 @@ QString ANSI_ESC_SEQ::next()
         _c, _c, _c, _c
     };
 
-    static QRegularExpression eseq("(0m|39m)|(1;1;1m|1;1m|1m)|(3[0-7]m|3[0-7];1m)|(1;3[0-7];1m)|(1;3[0-7]m)|(4[0-7]m)|(9[0-7]m)");
+    static QRegularExpression eseq("(0m|39m)|(1;1;1m|1;1m|1m)|(3[0-7]m|3[0-7];1m|3[0-7];1;1m)|(1;3[0-7];1m)|(1;3[0-7]m)|(4[0-7]m)|(9[0-7]m)");
     QRegularExpressionMatch m = eseq.match(src, pos + 2);
     QString p;
 


### PR DESCRIPTION
Actually, the fix changes the misinterpreted sequence from SGR::Formatting::Bold to SGR::Color(p[1].digitValue())
(OT: hope I got the PR process correct... never sure about these details.)
