### PR TITLE
simplied exit menu, working again, fixed QVariant type() usage warnings

### DIFF
--- a/Completion.cpp
+++ b/Completion.cpp
@@ -130,10 +130,10 @@ bool Completion::setup() {
         SwiPrologEngine::in_thread _e;
         try {
             if ( PlCall("load_files(library(console_input), [silent(true)])") &&
-		 PlCall("current_predicate(prolog:complete_input/4)")) {
-	        setup_status = available;
-	    }
+                 PlCall("current_predicate(prolog:complete_input/4)")) {
+            setup_status = available;
         }
+    }
         catch(PlException e) {
 //            qDebug() << CCP(e);
         }
@@ -146,6 +146,7 @@ bool Completion::setup() {
  * FIXME: Base tooltip on a callback
  */
 QString Completion::pred_tip(QTextCursor c) {
+    Q_UNUSED(c)
 #if 0
     if (helpidx_status == available) {
         c.select(c.WordUnderCursor);

--- a/ConsoleEdit.cpp
+++ b/ConsoleEdit.cpp
@@ -319,9 +319,9 @@ void ConsoleEdit::keyPressEvent(QKeyEvent *event) {
         if ((accept = editable) && ctrl)
         #endif
         {   qDebug() << "^D" << thids;
-	    c.movePosition(c.End);
+            c.movePosition(c.End);
             setTextCursor(c);
-	    ret = true;
+            ret = true;
             status = eof;
         }
         break;
@@ -381,8 +381,8 @@ void ConsoleEdit::keyPressEvent(QKeyEvent *event) {
         else
             emit user_input(cmd);
 
-	if ( status != eof || !cmd.isEmpty() )
-	    status = running;
+        if ( status != eof || !cmd.isEmpty() )
+            status = running;
     }
 }
 
@@ -882,7 +882,6 @@ void ConsoleEdit::add_history_line(QString line)
 void ConsoleEdit::eng_completed() {
     if (eng) {
         eng = 0;
-        // qApp->quit();
         QApplication::postEvent(qApp, new QCloseEvent);
     }
     else if (io) {

--- a/Preferences.cpp
+++ b/Preferences.cpp
@@ -91,9 +91,9 @@ Preferences::Preferences(QObject *parent) :
     for (int i = 0; i < 16; ++i) {
         setArrayIndex(i);
         QColor c = value("color", v[i]).value<QColor>();
-	if ( !c.isValid() )	// Play safe if the color is invalid
-	    c = v[i];		// Happens on MacOSX 10.11 (El Captain)
-	ANSI_sequences.append(c);
+        if ( !c.isValid() )	// Play safe if the color is invalid
+            c = v[i];		// Happens on MacOSX 10.11 (El Captain)
+        ANSI_sequences.append(c);
     }
     endArray();
 }

--- a/SwiPrologEngine.cpp
+++ b/SwiPrologEngine.cpp
@@ -117,14 +117,14 @@ ssize_t SwiPrologEngine::_read_(char *buf, size_t bufsize) {
             if (n > 0) {
                 uint l = bufsize < n ? bufsize : n;
                 memcpy(buf, buffer, l);
-		buffer.remove(0, l);
+                buffer.remove(0, l);
                 return l;
             }
 
             if (target->status == ConsoleEdit::eof) {
-	        target->status = ConsoleEdit::running;
+                target->status = ConsoleEdit::running;
                 return 0;
-	    }
+            }
         }
 
         if (PL_handle_signals() < 0)
@@ -352,9 +352,12 @@ bool SwiPrologEngine::in_thread::named_load(QString n, QString t, bool silent) {
  */
 bool SwiPrologEngine::quit_request() {
     qDebug() << "quit_request; spe = " << spe;
+    /*
     if (spe)
         spe->query_run("halt");
     else
         PL_halt(0);
     return false;
+    */
+    return true;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -124,7 +124,7 @@ int main(int argc, char *argv[]) {
     if ( (logname = getenv("QDEBUG")) ) {
         nolog = false;
         if ( strcmp(logname, "stderr") != 0 )
-	    logfile = fopen(logname, "w");
+            logfile = fopen(logname, "w");
     }
 
 #if QT_VERSION < 0x050000
@@ -136,6 +136,7 @@ int main(int argc, char *argv[]) {
     auto a = new swipl_win(argc, argv);
     int rc = a->exec();
     qDebug() << "main loop finished" << rc;
+delete a;
     return rc;
 }
 

--- a/pqMainWindow.cpp
+++ b/pqMainWindow.cpp
@@ -49,8 +49,8 @@ inline ConsoleEdit *wid2con(QWidget *w) { return qobject_cast<ConsoleEdit*>(w); 
 pqMainWindow::pqMainWindow(QWidget *parent) :
     QMainWindow(parent) {
 #ifndef __APPLE__
-  QMenuBar *mb = menuBar();
-  mb->setNativeMenuBar(false);
+    QMenuBar *mb = menuBar();
+    mb->setNativeMenuBar(false);
 #endif
 }
 
@@ -91,6 +91,8 @@ void pqMainWindow::closeEvent(QCloseEvent *event) {
 
     if (!SwiPrologEngine::quit_request())
         event->ignore();
+else
+    qApp->quit();
 }
 
 /** pass initialization script to actual interface

--- a/pqMainWindow.h
+++ b/pqMainWindow.h
@@ -93,7 +93,7 @@ public slots:
 protected:
 
     /** handle application closing, WRT XPCE termination */
-    virtual void closeEvent(QCloseEvent *event);
+    virtual void closeEvent(QCloseEvent *event) override;
 
     /** when there are more than a console, use a tabbed interface */
     QTabWidget *consoles() const;

--- a/swipl_win.cpp
+++ b/swipl_win.cpp
@@ -50,13 +50,13 @@ bool swipl_win::event(QEvent *event) {
     case QEvent::FileOpen:
       { QString name = static_cast<QFileOpenEvent *>(event)->file();
 
-	qDebug() << "FileOpen: " << name;
+        qDebug() << "FileOpen: " << name;
         SwiPrologEngine::in_thread _it;
-	try {
-	    PlCall("prolog", "file_open_event", PlTermv(name.toStdWString().data()));
-	} catch(PlException e) {
-	    qDebug() << CCP(e);
-	}
+        try {
+            PlCall("prolog", "file_open_event", PlTermv(name.toStdWString().data()));
+        } catch(PlException e) {
+            qDebug() << CCP(e);
+        }
         return true;
       }
     default:


### PR DESCRIPTION
I think the E&xit menu problem is not properly handled, it's rather complex, since it was written to handle 'subthreads' quitting...

Anyway, the main fix consisted in
1) properly routing the QCloseEvent from PREDICATE0(quit_console).
2) then adding qApp->quit(); in pqMainWindow::closeEvent
3) dramatically :) simplyfing bool SwiPrologEngine::quit_request() to return true instead of false - here is the part I think we should check further, now commented out

The QVariant type() deprecations have been solved with help from this interesting feed: https://embeddeduse.com/2021/01/17/migrating-a-harvester-hmi-from-qt-5-12-to-qt-6-0/

Also, some replacements of tabs with withespaces, since tabs were inserted with an editor expanding to 8 (virtual) spaces, but the majority of code was written with tabs expanded to 4 (physical) spaces.