### PR TITLE
factorized the menu mapper code subject to Qt versioning

### DIFF
--- a/pqMainWindow.h
+++ b/pqMainWindow.h
@@ -100,6 +100,9 @@ protected:
 
     /** route menus to prolog */
     QSignalMapper *menu2pl = nullptr;
+
+private:
+    QSignalMapper* menuMapper(ConsoleEdit *ce);
 };
 
 /** utility to lookup a typed parent in hierarchy */


### PR DESCRIPTION
Subject to Qt versioning previous to 5.15, we use the old (now deprecated) SIGNAL/SLOT dispatch based on stringified functions signatures. The fix was simple, just recovering the old code, I preferred to cleanup the login factorizing out the menu2pl construction and binding.
