### PR TITLE
fixed qmake.pro and includes to compile in QtCreator (up to Qt 6.4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ License.html
 Readme.html
 .qmake.stash
 TAGS
+*.user

--- a/SwiPrologEngine.cpp
+++ b/SwiPrologEngine.cpp
@@ -31,8 +31,6 @@
     POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <SWI-Stream.h>
-#include <SWI-cpp2.h>
 #include "SwiPrologEngine.h"
 #include "PREDICATE.h"
 

--- a/SwiPrologEngine.h
+++ b/SwiPrologEngine.h
@@ -34,6 +34,7 @@
 #ifndef SWIPROLOGENGINE_H
 #define SWIPROLOGENGINE_H
 
+#include <SWI-Stream.h>
 #include <SWI-cpp2.h>
 
 #include <QMap>

--- a/swipl-win.pro
+++ b/swipl-win.pro
@@ -13,9 +13,10 @@
 QT += core gui
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
+CONFIG += c++11
+
 macx {
     QT_CONFIG -= no-pkg-config
-    CONFIG += c++11
     ICON = swipl.icns
     QMAKE_MACOS_DEPLOYMENT_TARGET = 10.6
     QMAKE_MAC_SDK = macosx10.12
@@ -23,9 +24,6 @@ macx {
 
 TARGET = swipl-win
 TEMPLATE = app
-
-# please, not obsolete compiler
-QMAKE_CXXFLAGS += -std=c++0x
 
 # provide appropriate linking mode for
 # static compilation of pqConsole source files
@@ -59,7 +57,7 @@ unix {
 windows {
     SwiPl = "C:\Program Files\swipl"
     INCLUDEPATH += $$SwiPl\include
-    LIBS += -L$$SwiPl\bin -lswipl
+    LIBS += -L$$SwiPl\bin -llibswipl
 }
 
 mingw {


### PR DESCRIPTION
the (welcomed!) changes for SWI-cpp2.h left the project unbuildable, because of missing ssize_t definition