### PR TITLE
minimal implementation of ^Y

### DIFF
--- a/ConsoleEdit.cpp
+++ b/ConsoleEdit.cpp
@@ -179,18 +179,24 @@ void ConsoleEdit::setup() {
     connect(pasteQuoted, &QShortcut::activated, this, [&]() {
         exec_func([=]() {
             QTextCursor c = textCursor();
-            QChar stringDelim = '\'';
+
+            QChar stringDelim = QChar::Null;
             if (c.movePosition(c.Left, c.KeepAnchor)) {
                 auto s = c.selectedText();
                 auto d = s[0];
-                if (d == '`' || d == '"')
+                if (d ==  '\'' || d == '`' || d == '"')
                     stringDelim = d;
                 c.movePosition(c.Right);
             }
 
             auto text = QApplication::clipboard()->text();
             text.replace('\\', "\\\\");
-            text.replace(stringDelim, QString(stringDelim)+QString(stringDelim));
+
+            if (stringDelim != QChar::Null) {
+                text.replace(stringDelim, QString('\\')+QString(stringDelim));
+                text += stringDelim;
+            }
+
             c.insertText(text);
             do_events();
         });

--- a/ConsoleEdit.cpp
+++ b/ConsoleEdit.cpp
@@ -57,6 +57,7 @@
 #include <QMainWindow>
 #include <QApplication>
 #include <QStringListModel>
+#include <QClipboard>
 
 #include "ansi_esc_seq.h"
 
@@ -173,6 +174,27 @@ void ConsoleEdit::setup() {
 
     // so far,
     connect(this, SIGNAL(selectionChanged()), this, SLOT(selectionChanged()));
+
+    pasteQuoted = new QShortcut(QKeySequence("Ctrl+Y"), this);
+    connect(pasteQuoted, &QShortcut::activated, this, [&]() {
+        exec_func([=]() {
+            QTextCursor c = textCursor();
+            QChar stringDelim = '\'';
+            if (c.movePosition(c.Left, c.KeepAnchor)) {
+                auto s = c.selectedText();
+                auto d = s[0];
+                if (d == '`' || d == '"')
+                    stringDelim = d;
+                c.movePosition(c.Right);
+            }
+
+            auto text = QApplication::clipboard()->text();
+            text.replace('\\', "\\\\");
+            text.replace(stringDelim, QString(stringDelim)+QString(stringDelim));
+            c.insertText(text);
+            do_events();
+        });
+    });
 }
 
 /** set presentation attributes
@@ -323,6 +345,13 @@ void ConsoleEdit::keyPressEvent(QKeyEvent *event) {
             setTextCursor(c);
             ret = true;
             status = eof;
+        }
+        break;
+
+    case Key_Y:
+        if (ctrl) {
+            emit pasteQuoted->activated();
+            return;
         }
         break;
 

--- a/ConsoleEdit.h
+++ b/ConsoleEdit.h
@@ -53,6 +53,7 @@
 #include "ParenMatching.h"
 
 #include <QElapsedTimer>
+#include <QShortcut>
 
 class Swipl_IO;
 
@@ -245,6 +246,9 @@ protected:
 
     /** relax selection check requirement */
     QElapsedTimer sel_check_timing;
+
+protected:
+    QShortcut *pasteQuoted = nullptr;
 
 protected:
 


### PR DESCRIPTION
I was hoping that QShortcut could attach the event without any change in the keyboard handler. It was not the case.
